### PR TITLE
Fix tests - make config mutable again

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   test:
     working_directory: ~/knex-cleaner
     docker:
-      - image: cimg/node:14.21
+      - image: cimg/node:18.18.0
         environment:
           MYSQL_PORT: 3306
           PG_PORT: 5432
@@ -23,12 +23,12 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: dependency-cache-v14-{{ checksum "package-lock.json" }}
+          key: dependency-cache-v18-{{ checksum "package-lock.json" }}
       - run:
           name: install dependencies
           command: npm install
       - save_cache:
-          key: dependency-cache-v14-{{ checksum "package-lock.json" }}
+          key: dependency-cache-v18-{{ checksum "package-lock.json" }}
           paths:
             - ./node_modules
       - run:

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "chai": "4.3.x",
         "chai-as-promised": "7.1.x",
         "config": "^3.3.8",
-        "knex": "^2.4.0",
+        "knex": "^3.0.1",
         "mocha": "^10.2.0",
         "mysql": "^2.18.1",
         "pg": "^8.10.0",
@@ -25,7 +25,7 @@
         "sqlite3": "^5.1.6"
       },
       "engines": {
-        "node": ">= 14.0"
+        "node": ">= 16.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1508,12 +1508,12 @@
       "dev": true
     },
     "node_modules/commander": {
-      "version": "9.5.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
-      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
       "dev": true,
       "engines": {
-        "node": "^12.20.0 || >=14"
+        "node": ">=14"
       }
     },
     "node_modules/concat-map": {
@@ -3868,13 +3868,13 @@
       }
     },
     "node_modules/knex": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/knex/-/knex-2.4.2.tgz",
-      "integrity": "sha512-tMI1M7a+xwHhPxjbl/H9K1kHX+VncEYcvCx5K00M16bWvpYPKAZd6QrCu68PtHAdIZNQPWZn0GVhqVBEthGWCg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/knex/-/knex-3.0.1.tgz",
+      "integrity": "sha512-ruASxC6xPyDklRdrcDy6a9iqK+R9cGK214aiQa+D9gX2ZnHZKv6o6JC9ZfgxILxVAul4bZ13c3tgOAHSuQ7/9g==",
       "dev": true,
       "dependencies": {
         "colorette": "2.0.19",
-        "commander": "^9.1.0",
+        "commander": "^10.0.0",
         "debug": "4.3.4",
         "escalade": "^3.1.1",
         "esm": "^3.2.25",
@@ -3882,7 +3882,7 @@
         "getopts": "2.3.0",
         "interpret": "^2.2.0",
         "lodash": "^4.17.21",
-        "pg-connection-string": "2.5.0",
+        "pg-connection-string": "2.6.1",
         "rechoir": "^0.8.0",
         "resolve-from": "^5.0.0",
         "tarn": "^3.0.2",
@@ -3892,7 +3892,7 @@
         "knex": "bin/cli.js"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=16"
       },
       "peerDependenciesMeta": {
         "better-sqlite3": {
@@ -5366,9 +5366,9 @@
       "optional": true
     },
     "node_modules/pg-connection-string": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.5.0.tgz",
-      "integrity": "sha512-r5o/V/ORTA6TmUnyWZR9nCj1klXCO2CEKNRlVuJptZe85QuhFayC7WeMic7ndayT5IRIR0S0xFxFi2ousartlQ==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.6.1.tgz",
+      "integrity": "sha512-w6ZzNu6oMmIzEAYVw+RLK0+nqHPt8K3ZnknKi+g48Ak2pr3dtljJW3o+D/n2zzCG07Zoe9VOX3aiKpj+BN0pjg==",
       "dev": true
     },
     "node_modules/pg-int8": {
@@ -5410,12 +5410,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/pg/node_modules/pg-connection-string": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.6.1.tgz",
-      "integrity": "sha512-w6ZzNu6oMmIzEAYVw+RLK0+nqHPt8K3ZnknKi+g48Ak2pr3dtljJW3o+D/n2zzCG07Zoe9VOX3aiKpj+BN0pjg==",
-      "dev": true
     },
     "node_modules/pgpass": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "release": "release-it"
   },
   "engines": {
-    "node": ">= 14.0"
+    "node": ">= 16.0"
   },
   "repository": {
     "type": "git",
@@ -43,7 +43,7 @@
     "chai": "4.3.x",
     "chai-as-promised": "7.1.x",
     "config": "^3.3.8",
-    "knex": "^2.4.0",
+    "knex": "^3.0.1",
     "mocha": "^10.2.0",
     "mysql": "^2.18.1",
     "pg": "^8.10.0",

--- a/test/knex_cleaner.js
+++ b/test/knex_cleaner.js
@@ -7,6 +7,11 @@ const knexLib = require('knex');
 const knexCleaner = require('../lib/knex_cleaner');
 const knexTables = require('../lib/knex_tables');
 
+// Workaround a problem where config.get() returns a frozen/immutable
+// config, but knex's setHiddenProperty() expects to be able to modify
+// things. It's not a great solution, but it does work.
+process.env.ALLOW_CONFIG_MUTATIONS = 1;
+
 const knexMySQL = knexLib(config.get('mysql'));
 const knexPG = knexLib(config.get('pg'));
 const knexSqLite3 = knexLib(config.get('sqlite3'));


### PR DESCRIPTION
config.get() freezes the object it returns, while Knex's setHiddenProperty expects to be able to edit the objects (which seems rude).

The test now turns off the 'immutable' part, which isn't a great solution but will have to do until a better one is found.

See https://github.com/knex/knex/issues/