### PR TITLE
Fix chai-as-promised v8 plugin import in test setup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
       "devDependencies": {
         "@faker-js/faker": "^10.1.0",
         "chai": "4.3.x",
-        "chai-as-promised": "7.1.x",
+        "chai-as-promised": "8.0.x",
         "config": "^4.1.1",
         "knex": "^3.0.1",
         "mocha": "^11.1.0",
@@ -1158,15 +1158,26 @@
       }
     },
     "node_modules/chai-as-promised": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
-      "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-8.0.2.tgz",
+      "integrity": "sha512-1GadL+sEJVLzDjcawPM4kjfnL+p/9vrxiEUonowKOAzvVg0PixJUdtuDzdkDeQhK3zfOE76GqGkZIQ7/Adcrqw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "check-error": "^1.0.2"
+        "check-error": "^2.1.1"
       },
       "peerDependencies": {
-        "chai": ">= 2.1.2 < 5"
+        "chai": ">= 2.1.2 < 7"
+      }
+    },
+    "node_modules/chai-as-promised/node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/chalk": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "@faker-js/faker": "^10.1.0",
     "chai": "4.3.x",
-    "chai-as-promised": "7.1.x",
+    "chai-as-promised": "8.0.x",
     "config": "^4.1.1",
     "knex": "^3.0.1",
     "mocha": "^11.1.0",

--- a/test/knex_cleaner.js
+++ b/test/knex_cleaner.js
@@ -1,7 +1,8 @@
 const BPromise = require('bluebird');
 const { faker } = require('@faker-js/faker');
 const chai = require("chai");
-const chaiAsPromised = require("chai-as-promised");
+const chaiAsPromisedModule = require("chai-as-promised");
+const chaiAsPromised = chaiAsPromisedModule.default || chaiAsPromisedModule;
 const config = require('config');
 const knexLib = require('knex');
 const knexCleaner = require('../lib/knex_cleaner');


### PR DESCRIPTION
### Motivation
- Update test bootstrap to handle `chai-as-promised` v8 which exposes an ESM `default` export so `chai.use` receives a function instead of causing `TypeError: fn is not a function`.

### Description
- Modify `test/knex_cleaner.js` to load the module into a variable and pass `module.default || module` into `chai.use`, ensuring compatibility with both CJS and ESM module shapes.

### Testing
- Ran `npm test`; Mocha now starts and the previous `TypeError: fn is not a function` from `chai.use` is resolved, but several integration tests still fail due to environment `ECONNREFUSED` errors connecting to MySQL/Postgres.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2bcb5b36883278f3481e14e1c45f2)