### PR TITLE
Convert package and tests to ESM modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,11 @@ yarn add -D @solarwinter/knex-cleaner
 
 ### Usage
 ```javascript
-var knexCleaner = require('knex-cleaner');
+import knexCleaner from '@solarwinter/knex-cleaner';
 
-var knex = require('knex')({
+import knexLib from 'knex';
+
+const knex = knexLib({
   client: 'mysql',
   connection: {
     host     : '127.0.0.1',
@@ -35,7 +37,9 @@ knexCleaner.clean(knex).then(function() {
 });
 
 // You can also use this in BookshelfJS
-var bookshelf = require('bookshelf')(knex);
+import bookshelfLib from 'bookshelf';
+
+const bookshelf = bookshelfLib(knex);
 
 knexCleaner.clean(bookshelf.knex).then(function() {
 

--- a/lib/knex_cleaner.js
+++ b/lib/knex_cleaner.js
@@ -1,40 +1,36 @@
-'use strict';
+import BPromise from 'bluebird';
+import _ from 'lodash';
 
-var BPromise = require('bluebird');
-var _ = require('lodash');
+import { getTableNames, getPgSchema } from './knex_tables.js';
 
-var knexTables = require('../lib/knex_tables');
-
-var DefaultOptions = {
+const DefaultOptions = {
   mode: 'truncate',    // Can be ['truncate', 'delete']
   restartIdentity: true, // Used to tell PostgresSQL to reset the ID counter
   ignoreTables: []     // List of tables to not delete
 };
 
 function clean(knex, passedInOptions) {
-  var options = _.defaults({}, passedInOptions, DefaultOptions);
+  const options = _.defaults({}, passedInOptions, DefaultOptions);
 
-  return knexTables.getTableNames(knex, options)
+  return getTableNames(knex, options)
   .then(function(tables) {
     if (options.mode === 'delete') {
-      return cleanTablesWithDeletion(knex, tables, options);
-    } else {
-      return cleanTablesWithTruncate(knex, tables, options);
+      return cleanTablesWithDeletion(knex, tables);
     }
+    return cleanTablesWithTruncate(knex, tables, options);
   });
-
 }
 
-function cleanTablesWithDeletion(knex, tableNames, options) {
+function cleanTablesWithDeletion(knex, tableNames) {
   return BPromise.map(tableNames, function(tableName) {
     return knex.select().from(tableName).del();
   });
 }
 
 function cleanTablesWithTruncate(knex, tableNames, options) {
-  var client = knex.client.dialect;
+  const client = knex.client.dialect;
 
-  switch(client) {
+  switch (client) {
     case 'mysql':
       return knex.transaction(function(trx) {
         return knex.raw('SET FOREIGN_KEY_CHECKS=0').transacting(trx)
@@ -50,17 +46,16 @@ function cleanTablesWithTruncate(knex, tableNames, options) {
       });
     case 'postgresql':
       if (_.has(tableNames, '[0]')) {
-        var pgSchema = knexTables.getPgSchema(knex);
-        var quotedTableNames = tableNames.map(function(tableName) {
-          return pgSchema + '.' + '\"' + tableName + '\"';
+        const pgSchema = getPgSchema(knex);
+        const quotedTableNames = tableNames.map(function(tableName) {
+          return pgSchema + '.' + '"' + tableName + '"';
         });
-        // return knex.raw('TRUNCATE ' + quotedTableNames.join() + ' CASCADE');
         let rawSQL = 'TRUNCATE ' + quotedTableNames.join();
         if (options.restartIdentity) rawSQL += ' RESTART IDENTITY';
         rawSQL += ' CASCADE';
         return knex.raw(rawSQL);
       }
-      return;
+      return undefined;
     case 'sqlite3':
       return BPromise.map(tableNames, function(tableName) {
         return knex(tableName).truncate();
@@ -70,8 +65,5 @@ function cleanTablesWithTruncate(knex, tableNames, options) {
   }
 }
 
-module.exports = {
-  clean: function(knex, options) {
-    return clean(knex, options);
-  }
-};
+export { clean };
+export default { clean };

--- a/lib/knex_tables.js
+++ b/lib/knex_tables.js
@@ -1,26 +1,24 @@
-'use strict';
+import BPromise from 'bluebird';
+import _ from 'lodash';
 
-var BPromise = require('bluebird');
-var _ = require('lodash');
-
-var DefaultOptions = {
+const DefaultOptions = {
   ignoreTables: []     // List of tables to not filter out
 };
 
 function getTablesNameSql(knex) {
-  var client = knex.client.dialect;
-  var databaseName = knex.client.databaseName ||
+  const client = knex.client.dialect;
+  const databaseName = knex.client.databaseName ||
   knex.client.connectionSettings.database;
-  var pgSchema = getPgSchema(knex).replace(/"/g, "'");
+  const pgSchema = getPgSchema(knex).replace(/"/g, "'");
 
-  switch(client) {
+  switch (client) {
     case 'mysql':
       return "SELECT TABLE_NAME FROM information_schema.tables " +
       "WHERE TABLE_SCHEMA = '" + databaseName + "' " +
       "AND TABLE_TYPE = 'BASE TABLE'";
     case 'postgresql':
       return "SELECT tablename FROM pg_catalog.pg_tables" +
-      " WHERE schemaname=" + pgSchema + ";";
+      ' WHERE schemaname=' + pgSchema + ';';
     case 'sqlite3':
       return "SELECT name FROM sqlite_master WHERE type='table';";
     default:
@@ -30,9 +28,9 @@ function getTablesNameSql(knex) {
 }
 
 function getSqlRows(knex, resp) {
-  var client = knex.client.dialect;
+  const client = knex.client.dialect;
 
-  switch(client) {
+  switch (client) {
     case 'mysql':
       return resp[0];
     case 'postgresql':
@@ -45,9 +43,9 @@ function getSqlRows(knex, resp) {
 }
 
 function getDropTables(knex, tables) {
-  var client = knex.client.dialect;
+  const client = knex.client.dialect;
 
-  switch(client) {
+  switch (client) {
     case 'mysql':
       return knex.transaction(function(trx) {
         return knex.raw('SET FOREIGN_KEY_CHECKS=0').transacting(trx)
@@ -62,7 +60,7 @@ function getDropTables(knex, tables) {
         .then(trx.commit);
       });
     case 'postgresql':
-      return knex.raw('DROP TABLE IF EXISTS ' + tables.join(",") + ' CASCADE');
+      return knex.raw('DROP TABLE IF EXISTS ' + tables.join(',') + ' CASCADE');
     case 'sqlite3':
       return BPromise.map(tables, function(tableName) {
         return knex.schema.dropTable(tableName);
@@ -88,18 +86,19 @@ function getTableNames(knex, options) {
 }
 
 function getTableRowCount(knex, tableName) {
-  var client = knex.client.dialect;
+  const client = knex.client.dialect;
 
-  switch(client) {
+  switch (client) {
     case 'mysql':
       return knex(tableName).count().then(function(resp) {
         return Number(resp[0]['count(*)']);
       });
-    case 'postgresql':
-      var pgSchema = knex.client.searchPath || 'public';
+    case 'postgresql': {
+      const pgSchema = knex.client.searchPath || 'public';
       return knex(tableName).withSchema(pgSchema).count().then(function(resp) {
         return Number(resp[0].count);
       });
+    }
     case 'sqlite3':
       return knex(tableName).count().then(function(resp) {
         return Number(resp[0]['count(*)']);
@@ -110,26 +109,13 @@ function getTableRowCount(knex, tableName) {
 }
 
 function getPgSchema(knex) {
-  var pgSchema = knex.client.searchPath || 'public';
+  let pgSchema = knex.client.searchPath || 'public';
   if (_.isString(pgSchema)) {
     pgSchema = [pgSchema];
   }
   return pgSchema.map(function(schema) {
-    return '\"' + schema + '\"';
+    return '"' + schema + '"';
   }).join('.');
 }
 
-module.exports = {
-  getTableNames: function(knex, options) {
-    return getTableNames(knex, options);
-  },
-  getTableRowCount: function(knex, tableName) {
-    return getTableRowCount(knex, tableName);
-  },
-  getDropTables: function(knex, tables) {
-    return getDropTables(knex, tables);
-  },
-  getPgSchema: function(knex) {
-    return getPgSchema(knex);
-  },
-};
+export { getTableNames, getTableRowCount, getDropTables, getPgSchema };

--- a/package.json
+++ b/package.json
@@ -50,5 +50,9 @@
     "pg": "^8.10.0",
     "release-it": "^20.0.0",
     "sqlite3": "^6.0.1"
+  },
+  "type": "module",
+  "exports": {
+    ".": "./lib/knex_cleaner.js"
   }
 }

--- a/test/knex_cleaner.js
+++ b/test/knex_cleaner.js
@@ -1,11 +1,11 @@
-const BPromise = require('bluebird');
-const { faker } = require('@faker-js/faker');
-const chai = require("chai");
-const chaiAsPromised = require("chai-as-promised");
-const config = require('config');
-const knexLib = require('knex');
-const knexCleaner = require('../lib/knex_cleaner');
-const knexTables = require('../lib/knex_tables');
+import BPromise from 'bluebird';
+import { faker } from '@faker-js/faker';
+import chai from "chai";
+import chaiAsPromised from "chai-as-promised";
+import config from 'config';
+import knexLib from 'knex';
+import knexCleaner from '../lib/knex_cleaner.js';
+import * as knexTables from '../lib/knex_tables.js';
 
 // Workaround a problem where config.get() returns a frozen/immutable
 // config, but knex's setHiddenProperty() expects to be able to modify

--- a/test/knex_tables.js
+++ b/test/knex_tables.js
@@ -1,9 +1,9 @@
-const BPromise = require('bluebird');
-const chai = require("chai");
-const chaiAsPromised = require("chai-as-promised");
-const knex = require('knex');
-const config = require('config');
-const knexTables = require('../lib/knex_tables');
+import BPromise from 'bluebird';
+import chai from "chai";
+import chaiAsPromised from "chai-as-promised";
+import knex from 'knex';
+import config from 'config';
+import * as knexTables from '../lib/knex_tables.js';
 
 const knexMySQL = knex(config.get('mysql'));
 const knexPG = knex(config.get('pg'));


### PR DESCRIPTION
### Motivation
- Migrate the library and tests from CommonJS to native ESM so the package can be consumed with modern `import` syntax and Node's module resolution.
- Ensure local module imports use explicit `.js` extensions to satisfy ESM resolution rules.

### Description
- Converted `lib/knex_cleaner.js` and `lib/knex_tables.js` from `require`/`module.exports` to `import`/`export` and adjusted internal APIs to named and default exports (`export { clean }` and `export default { clean }`).
- Updated `package.json` to include `

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3ae3c71b08327b1c158445d8ccd28)