### PR TITLE
Fix Chai v5 import error in Mocha tests

### DIFF
--- a/test/knex_cleaner.js
+++ b/test/knex_cleaner.js
@@ -1,6 +1,6 @@
 import BPromise from 'bluebird';
 import { faker } from '@faker-js/faker';
-import chai from "chai";
+import * as chai from "chai";
 import chaiAsPromised from "chai-as-promised";
 import config from 'config';
 import knexLib from 'knex';


### PR DESCRIPTION
### Motivation
- Update tests to be compatible with Chai v5 which removed the default export and caused `SyntaxError: The requested module 'chai' does not provide an export named 'default'` when running Mocha.

### Description
- Replace the default import with a namespace import in `test/knex_cleaner.js` by changing `import chai from "chai";` to `import * as chai from "chai";`.

### Testing
- Ran `npm test`; Mocha now proceeds past the module-loading stage (original import error resolved) and test execution shows `9 passing` and `6 failing` with the remaining failures being `ECONNREFUSED` errors for MySQL/Postgres in the test environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3b61298ec832780f1f85a5264ac8a)