### PR TITLE
test: update DB versions, switch to matrix testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,12 +4,39 @@ on:
   push:
 
 jobs:
-  test:
+  sqlite:
     runs-on: ubuntu-latest
+
+    env:
+      TEST_DATABASES: sqlite3
+      SQLITE_FILE: ./knex_clean_test.sqlite
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Test
+        run: npm test
+
+  mariadb:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        mariadb-version: ['10.6', '10.11', '11.4']
 
     services:
       mariadb:
-        image: mariadb:10.6
+        image: mariadb:${{ matrix.mariadb-version }}
         env:
           MYSQL_USER: knex_cleaner
           MYSQL_PASSWORD: password
@@ -18,13 +45,52 @@ jobs:
         ports:
           - 3306:3306
         options: >-
-          --health-cmd="mysqladmin ping -h 127.0.0.1 -u$$MYSQL_USER -p$$MYSQL_PASSWORD"
+          --health-cmd="mariadb-admin ping -h 127.0.0.1 -u$$MYSQL_USER -p$$MYSQL_PASSWORD"
           --health-interval=10s
           --health-timeout=5s
           --health-retries=10
 
+    env:
+      TEST_DATABASES: mysql
+      MYSQL_HOST: 127.0.0.1
+      MYSQL_PORT: 3306
+      MYSQL_USER: knex_cleaner
+      MYSQL_PASSWORD: password
+      MYSQL_DB: knex_cleaner_test
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Wait for MariaDB
+        run: |
+          for i in {1..30}; do
+            nc -z 127.0.0.1 3306 && break
+            sleep 2
+          done
+
+      - name: Test
+        run: npm test
+
+  postgres:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        postgres-version: ['14', '15', '16', '17']
+
+    services:
       postgres:
-        image: postgres:13.20
+        image: postgres:${{ matrix.postgres-version }}
         env:
           POSTGRES_DB: knex_cleaner_test
           POSTGRES_USER: knex_cleaner
@@ -38,11 +104,7 @@ jobs:
           --health-retries=10
 
     env:
-      MYSQL_HOST: 127.0.0.1
-      MYSQL_PORT: 3306
-      MYSQL_USER: knex_cleaner
-      MYSQL_PASSWORD: password
-      MYSQL_DB: knex_cleaner_test
+      TEST_DATABASES: postgres
       PG_HOST: 127.0.0.1
       PG_PORT: 5432
       PG_USER: knex_cleaner
@@ -62,12 +124,8 @@ jobs:
       - name: Install dependencies
         run: npm install
 
-      - name: Wait for DBs
+      - name: Wait for PostgreSQL
         run: |
-          for i in {1..30}; do
-            nc -z 127.0.0.1 3306 && break
-            sleep 2
-          done
           for i in {1..30}; do
             nc -z 127.0.0.1 5432 && break
             sleep 2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,6 @@
-version: "3"
 services:
   mysql:
-    image: "mysql:8"
+    image: "mariadb:10.6"
     ports:
       - "8081:3306"
     environment:
@@ -9,9 +8,8 @@ services:
       MYSQL_PASSWORD: password
       MYSQL_DATABASE: knex_cleaner_test
       MYSQL_RANDOM_ROOT_PASSWORD: 1
-    command: --default-authentication-plugin=mysql_native_password
   postgres:
-    image: "postgres:11"
+    image: "postgres:14"
     ports:
       - "8082:5432"
     environment:

--- a/test/db_clients.js
+++ b/test/db_clients.js
@@ -1,0 +1,37 @@
+import config from 'config';
+import knexLib from 'knex';
+
+process.env.ALLOW_CONFIG_MUTATIONS = 1;
+
+const clientConfigGetters = {
+  mysql: () => config.get('mysql'),
+  postgres: () => config.get('pg'),
+  sqlite3: () => config.get('sqlite3')
+};
+
+const defaultClientNames = Object.keys(clientConfigGetters);
+
+function getEnabledClientNames() {
+  const envValue = process.env.TEST_DATABASES;
+  if (!envValue) {
+    return defaultClientNames;
+  }
+
+  return envValue
+    .split(',')
+    .map((name) => name.trim())
+    .filter(Boolean);
+}
+
+function getEnabledClients() {
+  return getEnabledClientNames().map((clientName) => {
+    const getConfig = clientConfigGetters[clientName];
+    if (!getConfig) {
+      throw new Error(`Unknown test database client: ${clientName}`);
+    }
+
+    return { client: clientName, knex: knexLib(getConfig()) };
+  });
+}
+
+export { getEnabledClients };

--- a/test/knex_cleaner.js
+++ b/test/knex_cleaner.js
@@ -2,30 +2,16 @@ import BPromise from 'bluebird';
 import { faker } from '@faker-js/faker';
 import * as chai from "chai";
 import chaiAsPromised from "chai-as-promised";
-import config from 'config';
-import knexLib from 'knex';
 import knexCleaner from '../lib/knex_cleaner.js';
 import * as knexTables from '../lib/knex_tables.js';
-
-// Workaround a problem where config.get() returns a frozen/immutable
-// config, but knex's setHiddenProperty() expects to be able to modify
-// things. It's not a great solution, but it does work.
-process.env.ALLOW_CONFIG_MUTATIONS = 1;
-
-const knexMySQL = knexLib(config.get('mysql'));
-const knexPG = knexLib(config.get('pg'));
-const knexSqLite3 = knexLib(config.get('sqlite3'));
+import { getEnabledClients } from './db_clients.js';
 
 const { expect } = chai;
 chai.should();
 chai.use(chaiAsPromised);
 
 describe('knex_cleaner', function() {
-  const clients = [
-    { client: 'mysql', knex: knexMySQL },
-    { client: 'postgres', knex: knexPG },
-    { client: 'sqllite', knex: knexSqLite3 },
-  ];
+  const clients = getEnabledClients();
 
   clients.forEach(function(dbTestValues) {
     const { knex, client } = dbTestValues;
@@ -36,7 +22,7 @@ describe('knex_cleaner', function() {
 
         return Promise.all(
           tableNames.map(tableName => {
-            if (tableName !== 'sqlite_sequence' || client !== 'sqllite') {
+            if (tableName !== 'sqlite_sequence' || client !== 'sqlite3') {
               return knex.schema.dropTable(tableName);
             }
           })

--- a/test/knex_tables.js
+++ b/test/knex_tables.js
@@ -1,22 +1,14 @@
 import BPromise from 'bluebird';
 import * as chai from "chai";
 import chaiAsPromised from "chai-as-promised";
-import knex from 'knex';
-import config from 'config';
 import * as knexTables from '../lib/knex_tables.js';
-
-const knexMySQL = knex(config.get('mysql'));
-const knexPG = knex(config.get('pg'));
-const knexSqLite3 = knex(config.get('sqlite3'));
+import { getEnabledClients } from './db_clients.js';
 
 chai.should();
 chai.use(chaiAsPromised);
 
 describe('knex_tables', function() {
-
-  [{ client: 'mysql', knex: knexMySQL }, { client: 'postgresql', knex: knexPG },
-    { client: 'sqlite3', knex: knexSqLite3}]
-  .forEach(function(dbTestValues) {
+  getEnabledClients().forEach(function(dbTestValues) {
 
     describe(dbTestValues.client, function() {
 


### PR DESCRIPTION
Rather than testing a single version of each database, it makes sense to use GitHub actions to test all the LTS/supported major versions.